### PR TITLE
clear up warnings due to use of ™ in lathe item.

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/Spinmaster Lathe.ash
+++ b/Source/relay/TourGuide/Items of the Month/Spinmaster Lathe.ash
@@ -1,7 +1,7 @@
 RegisterResourceGenerationFunction("IOTMSpinmasterLatheGenerateResource");
 void IOTMSpinmasterLatheGenerateResource(ChecklistEntry [int] resource_entries)
 {
-    if (available_amount($item[SpinMaster™ lathe]) < 1 || !is_unrestricted($item[SpinMaster™ lathe])) return;
+    if (available_amount($item[SpinMaster&trade; lathe]) < 1 || !is_unrestricted($item[SpinMaster&trade; lathe])) return;
  
 	if (!get_property_boolean("_spinmasterLatheVisited")) {
         string image_name = "__item purpleheart logs";


### PR DESCRIPTION
As title. No real code changes just removing the warnings when launching TourGuide.