### PR TITLE
Current std plans are <500 turns

### DIFF
--- a/Source/relay/TourGuide/Sections/Messages.ash
+++ b/Source/relay/TourGuide/Sections/Messages.ash
@@ -235,7 +235,7 @@ string generateRandomMessage()
             random_messages.listAppend("no king, forever");
         else if (my_daycount() >= 11)
             random_messages.listAppend("does the king even exist...?");
-        else if (my_turncount() > 500 && my_daycount() == 1)
+        else if (my_turncount() > 400 && my_daycount() == 1)
             random_messages.listAppend("you are ascending too... wait, what?");
         else if (gameday_to_int() == 7)
             random_messages.listAppend("you are ascending at a reasonable pace, could do better");


### PR DESCRIPTION
The random message for >500 turns on d1 references a 1d attempt. But
all current plans for 1d standard right now are for 450-496 turns.
Therefore this can be changed to >400 so that it will be seen. Of
course this is only going to be seen by a tiny collection of people,
but it is still funny.