### PR TITLE
adding a grey goose tile & cleaning up CBB

### DIFF
--- a/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
@@ -40,8 +40,8 @@ void IOTMGreyGooseResource(ChecklistEntry [int] resource_entries)
 
         int gooseExpToSix = max(36-$familiar[Grey Goose].experience,0);
 
-        main_title = "Goose Skills"
-        subtitle = "You have a " + gooseWeight + " pound Grey Goose."
+        main_title = "Goose Skills";
+        subtitle = "You have a " + gooseWeight + " pound Grey Goose.";
         // Only show descriptive stuff if the goose can use the skills (IE, weight > 5)
         if (gooseWeight > 5) 
         { 

--- a/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
@@ -1,0 +1,79 @@
+//Grey Goose
+RegisterTaskGenerationFunction("IOTMGreyGooseGenerateTasks");
+void IOTMGreyGooseGenerateTasks(ChecklistEntry [int] task_entries, ChecklistEntry [int] optional_task_entries, ChecklistEntry [int] future_task_entries)
+{
+    // This tile just posts up a task if your Goose is hefty enough to snag adventures, and you have it equipped.
+    int gooseWeight = min(floor(sqrt($familiar[Grey Goose].experience)),20);
+    string [int] description;
+
+     if (my_familiar() != lookupFamiliar("Grey Goose")) return;
+
+    // Surprisingly, the "class" is called Grey Goo even if the path is Grey You. This is not a typo!
+    if (my_class() == $class[grey goo] && gooseWeight > 5) 
+    {
+        string main_title = HTMLGenerateSpanFont("GOOSO is 6 pounds or higher", "grey");
+        description.listAppend("GOOSO IS LIT.");
+        description.listAppend("Re-Process a bunch of matter to gain a bunch of adventures, Grey You.");
+        task_entries.listAppend(ChecklistEntryMake("__familiar grey goose", "", ChecklistSubentryMake(main_title, "", description), -11));
+    }
+}
+
+RegisterResourceGenerationFunction("IOTMGreyGooseResource");
+void IOTMGreyGooseResource(ChecklistEntry [int] resource_entries)
+{
+    ChecklistSubentry gooseInfo() {
+
+        int gooseDrones = get_property_int("gooseDronesRemaining");
+        int gooseWeight = min(floor(sqrt($familiar[Grey Goose].experience)),20);
+        
+        // Return if you aren't in-run, because this tile is really not needed in aftercore. Commenting out for testing.
+        // if (!__misc_state["in run"]) return;
+        
+        string title;
+        string [int] description;
+
+        int dronesGenerated = max(gooseWeight-5,0);
+        int meatifyAmount = dronesGenerated**2;
+        int statGenerated = dronesGenerated**3;
+        int statGeneratedGoo = dronesGenerated**2;
+
+        int gooseExpToSix = max(36-$familiar[Grey Goose].experience,0);
+
+        main_title = "Goose Skills"
+        subtitle = "You have a " + gooseWeight + " pound Grey Goose."
+        // Only show descriptive stuff if the goose can use the skills (IE, weight > 5)
+        if (gooseWeight > 5) 
+        { 
+            if (my_class() == $class[grey goo]) 
+            {
+                description.listAppend(HTMLGenerateSpanOfClass("Re-Process Matter:", "r_bold") + " Get adventures from a monster, again!");
+                description.listAppend(HTMLGenerateSpanOfClass("Gain Stats:", "r_bold") + " Process for Protein, Energy, or Pomade for " + statGeneratedGoo + " mus/mys/mox.");
+            } else {
+                description.listAppend(HTMLGenerateSpanOfClass("Gain Stats:", "r_bold") + " Process for Protein, Energy, or Pomade for " + statGenerated + " mus/mys/mox substats.");
+            }
+            description.listAppend(HTMLGenerateSpanOfClass("Replication Drones:", "r_bold") + " Copy " + dronesGenerated + " items from monsters via drone warfare.");
+            description.listAppend(HTMLGenerateSpanOfClass("Meatify Matter:", "r_bold") + " Get " + meatifyAmount + " meat, instantly.");
+        } else {
+            description.listAppend("You can't use goose skills yet. Darn. Gain " + gooseExpToSix + " familiar XP to embrace GOOSO.");
+        }
+
+        return ChecklistSubentryMake(main_title, subtitle, description);
+
+    }
+    
+    // Return if the goose is not usable in your path (or you don't own it)
+    if (!lookupFamiliar("Grey Goose").familiar_is_usable()) return;
+
+    ChecklistEntry entry;
+    entry.image_lookup_name = "__familiar grey goose";
+    entry.tags.id = "Grey Goose familiar resource";
+
+    ChecklistSubentry skills = gooseInfo();
+    if skills.entries.count() > 0) {
+        entry.subentries.listAppend(skills);
+    }
+
+    if (entry.subentries.count() > 0) {
+        resource_entries.listAppend(entry);
+    }
+}

--- a/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
@@ -70,7 +70,7 @@ void IOTMGreyGooseResource(ChecklistEntry [int] resource_entries)
     entry.tags.id = "Grey Goose familiar resource";
 
     ChecklistSubentry skills = gooseInfo();
-    if skills.entries.count() > 0) {
+    if (skills.entries.count() > 0) {
         entry.subentries.listAppend(skills);
     }
 

--- a/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
+++ b/Source/relay/TourGuide/Items of the Month/2022/Grey Goose.ash
@@ -29,7 +29,8 @@ void IOTMGreyGooseResource(ChecklistEntry [int] resource_entries)
         // Return if you aren't in-run, because this tile is really not needed in aftercore. Commenting out for testing.
         // if (!__misc_state["in run"]) return;
         
-        string title;
+        string main_title;
+        string subtitle;
         string [int] description;
 
         int dronesGenerated = max(gooseWeight-5,0);

--- a/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
+++ b/Source/relay/TourGuide/Items of the Month/Items of the Month import.ash
@@ -117,3 +117,4 @@ import "relay/TourGuide/Items of the Month/2021/Cold Medicine Cabinet.ash";
 import "relay/TourGuide/Items of the Month/2022/Cursed Magnifying Glass.ash";
 import "relay/TourGuide/Items of the Month/2022/Cosmic Bowling Ball.ash";
 import "relay/TourGuide/Items of the Month/2022/Combat Lover Locket.ash";
+import "relay/TourGuide/Items of the Month/2022/Grey Goose.ash";

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -84,7 +84,7 @@ void initialiseIOTMsUsable()
         __iotms_usable[lookupItem("Distant Woods Getaway Brochure")] = true;
     if (lookupItem("Eight Days a Week Pill Keeper").available_amount() > 0)
         __iotms_usable[lookupItem("Eight Days a Week Pill Keeper")] = true;
-	if (lookupItem("cosmic bowling ball").available_amount() > 0 || get_property_int("_cosmicBowlingSkillsUsed") > 0)
+    if (lookupItem("cosmic bowling ball").available_amount() > 0 || get_property_int("_cosmicBowlingSkillsUsed") > 0)
         // change to use tracking property if/when mafia adds one from coolitems.php
         __iotms_usable[lookupItem("cosmic bowling ball")] = true;
     if ($item[clan vip lounge key].item_amount() > 0)

--- a/Source/relay/TourGuide/Support/IOTMs.ash
+++ b/Source/relay/TourGuide/Support/IOTMs.ash
@@ -84,7 +84,7 @@ void initialiseIOTMsUsable()
         __iotms_usable[lookupItem("Distant Woods Getaway Brochure")] = true;
     if (lookupItem("Eight Days a Week Pill Keeper").available_amount() > 0)
         __iotms_usable[lookupItem("Eight Days a Week Pill Keeper")] = true;
-	if (lookupItem("cosmic bowling ball").available_amount() > 0)
+	if (lookupItem("cosmic bowling ball").available_amount() > 0 || get_property_int("_cosmicBowlingSkillsUsed") > 0)
         // change to use tracking property if/when mafia adds one from coolitems.php
         __iotms_usable[lookupItem("cosmic bowling ball")] = true;
     if ($item[clan vip lounge key].item_amount() > 0)


### PR DESCRIPTION
main goal of this PR is the grey goose tile. goose tile includes a resource brick like so: 

![image](https://user-images.githubusercontent.com/8014761/165187369-f9df5ee9-1494-4849-ba2a-c9272c2a878b.png)

and a task alert in the "Grey You" path reminding users they can re-process matter for more adventures.

![image](https://user-images.githubusercontent.com/8014761/165187418-01b6939f-90d9-4819-9d5c-0b08fa77d341.png)

have tested briefly. seems fine. will merge this into main (then bundled -> release) in a few hours.